### PR TITLE
Fully integrate joinme.click to join servers from the dashboard

### DIFF
--- a/src/BF2Dashboard.Domain/BattlefieldApi/Server.cs
+++ b/src/BF2Dashboard.Domain/BattlefieldApi/Server.cs
@@ -157,6 +157,12 @@ public class Server
     [JsonPropertyName("noVehicles")]
     public bool? NoVehicles { get; set; }
 
+    [JsonPropertyName("joinLink")]
+    public string? JoinLink { get; set; }
+
+    [JsonPropertyName("joinLinkWeb")]
+    public string? JoinLinkWeb { get; set; }
+
     [JsonPropertyName("teams")]
     public List<Team>? Teams { get; set; }
 

--- a/src/BF2Dashboard.UI/Pages/Dashboard.razor
+++ b/src/BF2Dashboard.UI/Pages/Dashboard.razor
@@ -19,7 +19,7 @@
 <div class="col-md-6 pt-5 mt-2">
     @if (_fullServerListState.Value.ServerList != null && _friendListState.Value.IsLoading == false && _friendListState.Value.IsInitialized)
     {
-        <h3>Online Friends:</h3>
+        <h3>Online Friends</h3>
         <div class="row p-2 ms-4">
             @if (_friendListState.Value.IsEmpty)
             {
@@ -64,7 +64,7 @@ else
 {
     <div class="col-md-6">
         <div class="pt-2 pb-2">
-            <h3>All Battlefield 2 Servers:</h3>
+            <h3>All Battlefield 2 Servers</h3>
         </div>
         <div class="accordion accordion-flush bg-dark" id="mainAccordion">
             @foreach (var server in _fullServerListState.Value.ServerList)
@@ -221,7 +221,7 @@ else
     </div>
     <div class="col-md-6">
         <div class="pt-2 pb-2">
-            <h3>Your favorites:</h3>
+            <h3>Your favorites</h3>
         </div>
         <div class="accordion accordion-flush bg-dark" id="favoritesAccordion">
             @if (_favoriteServerListState.Value.ServerList?.Any() == true)

--- a/src/BF2Dashboard.UI/Pages/Dashboard.razor
+++ b/src/BF2Dashboard.UI/Pages/Dashboard.razor
@@ -41,6 +41,10 @@
                                 <span style="font-size: 10pt; color: #767676">
                                     @friend.ServerInfo.MapName @@ @friend.ServerInfo.ServerName 
                                     (@friend.ServerInfo.CurrentPlayerCountWithoutBots/@friend.ServerInfo.MaxPlayerCount)
+                                    @if (friend.ServerInfo.JoinLink != null)
+                                    {
+                                        <a role="button" title="Join server (requires joinme.click launcher)" href="@friend.ServerInfo.JoinLink" class="btn btn-dark btn-sm mx-2">Join</a>
+                                    }
                                 </span>
                             </li>
                         }

--- a/src/BF2Dashboard.UI/Pages/Dashboard.razor
+++ b/src/BF2Dashboard.UI/Pages/Dashboard.razor
@@ -127,9 +127,10 @@ else
                                 <div class="row d-flex justify-content-center text-center">
                                     <span class="mb-4">
                                         <small><strong>Server IP</strong>: @server.Ip:@server.Port</small>
-                                        <a title="Join server" target="_blank" href="https://joinme.click/g/bf2/@server.Ip:@server.Port">
-                                            Join
-                                        </a>
+                                        @if (server.JoinLink != null)
+                                        {
+                                            <a role="button" title="Join server (requires joinme.click launcher)" href="@server.JoinLink" class="btn btn-dark btn-sm mx-2">Join</a>
+                                        }
                                     </span>
                                 </div>
                                 @if (server.NumPlayersWithoutBots > 0)

--- a/src/BF2Dashboard.UI/Pages/FAQ.razor
+++ b/src/BF2Dashboard.UI/Pages/FAQ.razor
@@ -1,50 +1,41 @@
 ﻿@page "/faq"
 
 <h3>Frequently Asked Questions</h3>
-<div class="container">
+<div>
     <div class="m-9">
-        <ul>
+        <h5 id="faq-meaning">What does <q>FAQ</q> stand for?</h5>
+        <p>
+            <q>Frequently Asked Questions</q>
+        </p>
+
+        <h5 id="status" class="mt-5">Why is the site so empty/unfinished?</h5>
+        <p>
+            It's in early development. Continuously improved in my free time. Come back later for more improvements.
+            <a href="https://github.com/TwitchPlaysBF2/BF2Dashboard/commits/main" target="_blank">
+                <img src="https://img.shields.io/github/last-commit/TwitchPlaysBF2/BF2Dashboard/main?label=Latest%20change%3A&logo=github&logoColor=9147FF&style=flat-square" alt="Latest change"/>
+            </a>
+        </p>
+
+        <h5 id="joinme-click" class="mt-5">What is the joinme.click launcher?</h5>
+        <p>
+            The <a href="https://joinme.click" target="_blank">joinme.click</a> launcher allows you to launch the game and join servers directly from the dashboard.
+            Simply click the "Join" button on a server or friend list entry and you can start playing. You can download the launcher and find further details here: <a href="https://joinme.click/download" target="_blank">joinme.click/download</a>
+        </p>
+
+        <h5 id="custom-maps" class="mt-5">Where can I download custom modded maps for competitive BF2 modes like "2 vs. 2 in a Helicopter"?</h5>
+        <p>
+            Here: <a class="link" href="https://bf2.nihlen.net/maps">bf2.nihlen.net/maps</a>
+        </p>
+
+        <h5 id="how-to-play" class="mt-5">How can I play Battlefield 2 in @DateTime.Now.Year?</h5>
+        <ol>
             <li>
-                What does <strong>FAQ</strong> stand for?
-                <ul>
-                    <li>
-                        &bdquo;Frequently Asked Questions&rdquo;
-                    </li>
-                </ul>
+                Download and install the <a class="link" target="_blank" href="https://www.bf2hub.com">BF2Hub Client</a>
             </li>
             <li>
-                Why is <strong>BF2.TV</strong> so empty/unfinished?
-                <ul>
-                    <li>
-                        It's in early development. Continuously improved in my free time. Come back later for more improvements.
-                    </li>
-                    <li>
-                        <a href="https://github.com/TwitchPlaysBF2/BF2Dashboard/commits/main" target="_blank">
-                            <img src="https://img.shields.io/github/last-commit/TwitchPlaysBF2/BF2Dashboard/main?label=Latest%20change%3A&logo=github&logoColor=9147FF&style=flat-square" alt="Latest change"/>
-                        </a>
-                    </li>
-                </ul>
+                Download and install the <a class="link" target="_blank" href="https://mega.nz/file/0wJhRYhK#9zYuv09dWSE0eQ9mFHgx71hLWW2AOKq3X3n7bKRJvUY">Full BF2 Setup with license verification + patches + addons included, provided by Lost-Soliders.org</a>
             </li>
-            <li>
-                Where can I download custom modded maps for <strong>competitive BF2</strong> modes like "2 vs. 2 in a Helicopter"?
-                <ul>
-                    <li>
-                        Here: <a class="link" href="https://bf2.nihlen.net/maps">bf2.nihlen.net/maps</a>
-                    </li>
-                </ul>
-            </li>
-            <li>
-                How can I play <strong>Battlefield 2</strong> in @DateTime.Now.Year?
-                <ol>
-                    <li>
-                        Download and install the <a class="link" target="_blank" href="https://www.bf2hub.com">BF2Hub Client</a>
-                    </li>
-                    <li>
-                        Download and install the <a class="link" target="_blank" href="https://mega.nz/file/0wJhRYhK#9zYuv09dWSE0eQ9mFHgx71hLWW2AOKq3X3n7bKRJvUY">Full BF2 Setup with license verification + patches + addons included, provided by Lost-Soliders.org</a>
-                    </li>
-                </ol>
-            </li>
-        </ul>
+        </ol>
     </div>
 </div>
 

--- a/src/BF2Dashboard.UI/Pages/FriendList.razor
+++ b/src/BF2Dashboard.UI/Pages/FriendList.razor
@@ -24,6 +24,10 @@ else
                     <span style="font-size: 10pt; color: #767676">
                         @friend.ServerInfo.MapName @@ @friend.ServerInfo.ServerName 
                         (@friend.ServerInfo.CurrentPlayerCountWithoutBots/@friend.ServerInfo.MaxPlayerCount)
+                        @if (friend.ServerInfo.JoinLink != null)
+                        {
+                            <a role="button" title="Join server (requires joinme.click launcher)" href="@friend.ServerInfo.JoinLink" class="btn btn-dark btn-sm mx-2">Join</a>
+                        }
                     </span>
                     <i class="btn btn-sm btn-outline-warning bi bi-person-dash grow" @onclick="() => RemoveFriend(friend)" title="Remove friend"></i>
                 </li>

--- a/src/BF2Dashboard.UI/Store/ServerInfoModel.cs
+++ b/src/BF2Dashboard.UI/Store/ServerInfoModel.cs
@@ -12,6 +12,8 @@ public class ServerInfoModel
 
     public int MaxPlayerCount { get; private init; }
 
+    public string JoinLink { get; private init; }
+
     public static ServerInfoModel FromServer(Server server)
     {
         return new ServerInfoModel
@@ -20,6 +22,7 @@ public class ServerInfoModel
             MapName = server.MapName,
             CurrentPlayerCountWithoutBots = server.NumPlayersWithoutBots,
             MaxPlayerCount = (int?)server.MaxPlayers ?? 0,
+            JoinLink = server.JoinLink,
         };
     }
 }


### PR DESCRIPTION
Brief summary of changes:
- use join link provided by bflist API (instead of constructing it locally)
- only show join link if server runs a mod supported by the launcher
- turn text link into a simple button
- let users join directly from the dashboard (skip the trip to the joinme.click website)
- add join button to friend list
- add FAQ entry regarding joinme.click launcher
- restyle FAQ
- add html ids to FAQ entries so they can be linked to directly (e.g. `bf2.tv/faq#custom-maps`)