### PR TITLE
Show map size as well when showing map name

### DIFF
--- a/src/BF2TV.Domain/BattlefieldApi/Server.cs
+++ b/src/BF2TV.Domain/BattlefieldApi/Server.cs
@@ -15,6 +15,8 @@ public class Server
 
     public string IpAndPort => Ip + ":" + Port;
 
+    public string MapNameAndSize => $"{MapName} ({MapSize})";
+
     public GeoLocation? GeoLocation { get; set; }
 
     [JsonPropertyName("guid")]
@@ -39,7 +41,7 @@ public class Server
     public string MapName { get; set; }
 
     [JsonPropertyName("mapSize")]
-    public float? MapSize { get; set; }
+    public float MapSize { get; set; }
 
     [JsonPropertyName("password")]
     public bool? Password { get; set; }

--- a/src/BF2TV.Frontend/Pages/Dashboard.razor
+++ b/src/BF2TV.Frontend/Pages/Dashboard.razor
@@ -46,7 +46,7 @@
                                 <i class="bi bi-circle-fill" style="color: green; font-size: 11pt;"></i>
                                 @friend.DisplayName
                                 <span style="font-size: 10pt; color: #767676">
-                                    @friend.ServerInfo.MapName @@ <a href="servers/@friend.ServerInfo.IpAndPort" style="color: slategrey">@friend.ServerInfo.ServerName</a>
+                                    @friend.ServerInfo.MapNameAndSize @@ <a href="servers/@friend.ServerInfo.IpAndPort" style="color: slategrey">@friend.ServerInfo.ServerName</a>
                                     (@friend.ServerInfo.CurrentPlayerCountWithoutBots/@friend.ServerInfo.MaxPlayerCount)
                                     @if (friend.ServerInfo.JoinLink != null)
                                     {
@@ -128,7 +128,7 @@ else
                                     </div>
                                     <div class="row">
                                         <small>
-                                            <span style="color: #747474">@server.MapName</span>
+                                            <span style="color: #747474">@server.MapNameAndSize</span>
                                         </small>
                                     </div>
                                 </div>
@@ -291,7 +291,7 @@ else
                                         </div>
                                         <div class="row">
                                             <small>
-                                                <span style="color: #747474">@server.MapName</span>
+                                                <span style="color: #747474">@server.MapNameAndSize</span>
                                             </small>
                                         </div>
                                     </div>

--- a/src/BF2TV.Frontend/Pages/FriendList.razor
+++ b/src/BF2TV.Frontend/Pages/FriendList.razor
@@ -23,7 +23,7 @@
                         <i class="bi bi-circle-fill" style="color: green; font-size: 11pt;"></i>
                         @friend.DisplayName
                         <span style="font-size: 10pt; color: #767676">
-                            @friend.ServerInfo.MapName @@ <a href="servers/@friend.ServerInfo.IpAndPort" style="color: slategrey">@friend.ServerInfo.ServerName</a>
+                            @friend.ServerInfo.MapNameAndSize @@ <a href="servers/@friend.ServerInfo.IpAndPort" style="color: slategrey">@friend.ServerInfo.ServerName</a>
                             (@friend.ServerInfo.CurrentPlayerCountWithoutBots/@friend.ServerInfo.MaxPlayerCount)
                             @if (friend.ServerInfo.JoinLink != null)
                             {

--- a/src/BF2TV.Frontend/Store/FriendList/FriendListStore.cs
+++ b/src/BF2TV.Frontend/Store/FriendList/FriendListStore.cs
@@ -157,7 +157,7 @@ public class FriendListEffects
     {
         var friendModels = CreateFriendModels(action.FriendNameList, action.ServerList).ToList();
         var onlineFriendList = friendModels.Where(m => m.IsOnline)
-            .OrderBy(m => m.ServerInfo?.MapName)
+            .OrderBy(m => m.ServerInfo?.MapNameAndSize)
             .ThenBy(m => m.ServerInfo?.ServerName)
             .ThenBy(m => m.DisplayName)
             .ToList();

--- a/src/BF2TV.Frontend/Store/ServerInfoModel.cs
+++ b/src/BF2TV.Frontend/Store/ServerInfoModel.cs
@@ -15,6 +15,8 @@ public class ServerInfoModel
     public string? JoinLink { get; private init; }
 
     public string IpAndPort { get; private init; }
+    
+    public string MapNameAndSize { get; private init; }
 
     public static ServerInfoModel FromServer(Server server)
     {
@@ -22,6 +24,7 @@ public class ServerInfoModel
         {
             ServerName = server.Name,
             MapName = server.MapName,
+            MapNameAndSize = server.MapNameAndSize,
             CurrentPlayerCountWithoutBots = server.NumPlayersWithoutBots,
             MaxPlayerCount = (int?)server.MaxPlayers ?? 0,
             JoinLink = server.JoinLink,

--- a/src/BF2TV.WindowsApp/Infrastructure/Tray/TrayService.cs
+++ b/src/BF2TV.WindowsApp/Infrastructure/Tray/TrayService.cs
@@ -44,7 +44,7 @@ public class TrayService : IDisposable
         {
             var title = $"[{server.NumPlayersWithoutBots}/{server.MaxPlayers}] {server.Name}";
             var item = new ToolStripMenuItem(title, null, (_, _) => OnJoinServer(server), title);
-            item.ToolTipText = $@"Map: {server.MapName}";
+            item.ToolTipText = $@"Map: {server.MapNameAndSize}";
             _trayItemFavorites.DropDown.Items.Add(item);
         }
 


### PR DESCRIPTION
Not all servers run the map size that corresponds to the number of slots. So, show the map size too using the format `{mapName} ({mapSize})`.