### PR TITLE
fix: Link to BF2Hub profiles using the pid instead of the name

### DIFF
--- a/src/BF2TV.Domain/BattlefieldApi/Player.cs
+++ b/src/BF2TV.Domain/BattlefieldApi/Player.cs
@@ -13,6 +13,10 @@ public class Player
     public bool IsFriend { get; set; } = false;
 
     public string FullName => Tag + " " + Name;
+
+    // Long names of player may be cut off if used in combination with a clan tag/prefix,
+    // meaning linking to the cut-off name would lead to a 404 => link to profile based on pid instead
+    public string ProfileUrl => $"https://www.bf2hub.com/stats/{Pid}";
     
     [JsonPropertyName("pid")]
     public int? Pid { get; set; }

--- a/src/BF2TV.Frontend/Pages/Dashboard.razor
+++ b/src/BF2TV.Frontend/Pages/Dashboard.razor
@@ -174,7 +174,7 @@ else
                                                     <tr>
                                                         <td style="vertical-align: center;">
                                                             <a title="Open BF2Hub profile" class="link-light text-nowrap text-decoration-none" target="_blank"
-                                                               href="https://www.bf2hub.com/player/@player.Name">
+                                                               href="@player.ProfileUrl">
                                                                 <span style="color: @(player.IsFriend ? "darkseagreen" : "")">@player.FullName</span>
                                                             </a>
                                                         </td>
@@ -209,7 +209,7 @@ else
                                                     <tr>
                                                         <td>
                                                             <a title="Open BF2Hub profile" class="link-light text-nowrap text-decoration-none" target="_blank"
-                                                               href="https://www.bf2hub.com/player/@player.Name">
+                                                               href="@player.ProfileUrl">
                                                                 <span style="color: @(player.IsFriend ? "darkseagreen" : "")">@player.FullName</span>
                                                             </a>
                                                         </td>
@@ -337,7 +337,7 @@ else
                                                         <tr>
                                                             <td>
                                                                 <a title="Open BF2Hub profile" class="link-light text-nowrap text-decoration-none" target="_blank"
-                                                                   href="https://www.bf2hub.com/player/@player.Name">
+                                                                   href="@player.ProfileUrl">
                                                                     <span style="color: @(player.IsFriend ? "darkseagreen" : "")">@player.FullName</span>
                                                                 </a>
                                                             </td>
@@ -372,7 +372,7 @@ else
                                                         <tr>
                                                             <td>
                                                                 <a title="Open BF2Hub profile" class="link-light text-nowrap text-decoration-none" target="_blank"
-                                                                   href="https://www.bf2hub.com/player/@player.Name">
+                                                                   href="@player.ProfileUrl">
                                                                     <span style="color: @(player.IsFriend ? "darkseagreen" : "")">@player.FullName</span>
                                                                 </a>
                                                             </td>

--- a/src/BF2TV.Frontend/Pages/ServerPage.razor
+++ b/src/BF2TV.Frontend/Pages/ServerPage.razor
@@ -74,7 +74,7 @@
                                 <tr>
                                     <td>
                                         <a title="Open BF2Hub profile" class="link-light text-nowrap text-decoration-none" target="_blank"
-                                           href="https://www.bf2hub.com/player/@player.Name">
+                                           href="@player.ProfileUrl">
                                             <span style="color: @(player.IsFriend ? "darkseagreen" : "")">@player.FullName</span>
                                         </a>
                                     </td>
@@ -105,7 +105,7 @@
                                 <tr>
                                     <td>
                                         <a title="Open BF2Hub profile" class="link-light text-nowrap text-decoration-none" target="_blank"
-                                           href="https://www.bf2hub.com/player/@player.Name">
+                                           href="@player.ProfileUrl">
                                             <span style="color: @(player.IsFriend ? "darkseagreen" : "")">@player.FullName</span>
                                         </a>
                                     </td>


### PR DESCRIPTION
I recently noticed that long player names name are cut off by the server in rare cases. For example, "=TwF= Dr.Fratzengeballer" is returned as "=TwF= Dr.Fratzengeballe" (r is missing). This seems to a limitation of either the GameSpy query protocol or an oversight on the BF2 server. Feels like the devs forgot to account for the space, so they only have space for max length tag + max length name, but not for the space in between.

Anyways, I don't think I will be able to fix this on the bflist side of things. I'd have to lookup the pid of every online player against both BF2Hub and PlayBF2, which is not feasible. It also won't cover all the bots etc, so it's not even a 100% fix.

The much, much easier solution: Use the pid to link to the BF2Hub profile.