### PR TITLE
Stop server community logo from overflowing it's container

### DIFF
--- a/src/BF2TV.Frontend/Pages/ServerPage.razor
+++ b/src/BF2TV.Frontend/Pages/ServerPage.razor
@@ -131,7 +131,7 @@
             <div class="m-4 text-center">
                 @if (!string.IsNullOrWhiteSpace(Server.CommunityLogoUrl))
                 {
-                    <img src="@Server.CommunityLogoUrl" alt="Server"/>
+                    <img src="@Server.CommunityLogoUrl" alt="Server" style="max-width: 100%;"/>
                     <br/>
                 }
                 @if (Uri.IsWellFormedUriString(Server.SponsorText, UriKind.Absolute))


### PR DESCRIPTION
The community logo currently overflows it's container if the image is bigger than the expected size.

![image](https://user-images.githubusercontent.com/17167062/226682339-3ff7d551-298a-4028-9021-564aed61503d.png)

By simply setting `max-width: 100%;`, we can ensure that the image is never bigger than it's container.

![image](https://user-images.githubusercontent.com/17167062/226683113-a742aaa0-8cb5-43db-b3e2-b917c9917cbc.png)


