### PR TITLE
feat: Add discord and demo button to dashboard

### DIFF
--- a/src/BF2TV.Frontend/Pages/Dashboard.razor
+++ b/src/BF2TV.Frontend/Pages/Dashboard.razor
@@ -13,6 +13,7 @@
 @inject IEnvironment Environment
 @inject IActivePlayerLookupService ActivePlayerLookupService
 @inject IPeriodicRefresher PeriodicRefresher
+@inject DiscordUrlParser _discordUrlParser
 
 @if (Environment.IsApp() && _activePlayerName != null)
 {
@@ -156,16 +157,30 @@ else
                             <div class="accordion-body ps-5 pe-3 pb-5">
                                 <div class="row d-flex justify-content-center text-center">
                                     <span>
-                                        <a role="button" href="servers/@server.IpAndPort" class="btn btn-dark btn-sm mx-2">Server Details</a>
+                                        <a role="button" href="servers/@server.IpAndPort" class="btn btn-dark btn-sm mx-1">
+                                            <i class="bi bi-info-circle icon-in-a-button-small align-middle"></i> <span class="align-middle">Server Details</span>
+                                        </a>
+                                        @if (server.JoinLink != null)
+                                        {
+                                            <a role="button" title="Join server (requires joinme.click/download)" href="@server.JoinLink" class="btn btn-dark btn-sm mx-1">
+                                                <i class="bi bi-play-circle icon-in-a-button-small align-middle"></i> <span class="align-middle">Join server</span>
+                                            </a>
+                                        }
+                                        @if (_discordUrlParser.TryGetDiscordUrl(server.SponsorText, out var discordUrl))
+                                        {
+                                            <a role="button" class="btn btn-dark btn-sm mx-1" target="_blank" href="@discordUrl">
+                                                <i class="bi bi-discord icon-in-a-button-small align-middle"></i> <span class="align-middle">Join Discord</span>
+                                            </a>
+                                        }
+                                        @if (server.Battlerecorder == true && !string.IsNullOrWhiteSpace(server.DemoIndex) && Uri.IsWellFormedUriString(server.DemoIndex, UriKind.Absolute))
+                                        {
+                                            <a role="button" class="btn btn-dark btn-sm mx-1" target="_blank" href="@server.DemoIndex">
+                                                <i class="bi bi-camera-video icon-in-a-button-small align-middle"></i> <span class="align-middle">Demos</span>
+                                            </a>
+                                        }
                                     </span>
                                     <span class="mb-4">
                                         <small><strong>Server IP</strong>: @server.IpAndPort</small>
-                                        @if (server.JoinLink != null)
-                                        {
-                                            <a role="button" title="Join server (requires joinme.click/download)" href="@server.JoinLink" class="btn btn-dark btn-sm mx-2">
-                                                <i class="bi bi-play-circle icon-in-a-button-small"></i> Join
-                                            </a>
-                                        }
                                     </span>
                                 </div>
                                 @if (server.NumPlayersWithoutBots > 0)
@@ -319,16 +334,30 @@ else
                                 <div class="accordion-body ps-5 pe-3 pb-5">
                                     <div class="row d-flex justify-content-center text-center">
                                         <span>
-                                            <a role="button" href="servers/@server.IpAndPort" class="btn btn-dark btn-sm mx-2">Server Details</a>
+                                            <a role="button" href="servers/@server.IpAndPort" class="btn btn-dark btn-sm mx-1">
+                                                <i class="bi bi-info-circle icon-in-a-button-small align-middle"></i> <span class="align-middle">Server Details</span>
+                                            </a>
+                                            @if (server.JoinLink != null)
+                                            {
+                                                <a role="button" title="Join server (requires joinme.click/download)" href="@server.JoinLink" class="btn btn-dark btn-sm mx-1">
+                                                    <i class="bi bi-play-circle icon-in-a-button-small align-middle"></i> <span class="align-middle">Join server</span>
+                                                </a>
+                                            }
+                                            @if (_discordUrlParser.TryGetDiscordUrl(server.SponsorText, out var discordUrl))
+                                            {
+                                                <a role="button" class="btn btn-dark btn-sm mx-1" target="_blank" href="@discordUrl">
+                                                    <i class="bi bi-discord icon-in-a-button-small align-middle"></i> <span class="align-middle">Join Discord</span>
+                                                </a>
+                                            }
+                                            @if (server.Battlerecorder == true && !string.IsNullOrWhiteSpace(server.DemoIndex) && Uri.IsWellFormedUriString(server.DemoIndex, UriKind.Absolute))
+                                            {
+                                                <a role="button" class="btn btn-dark btn-sm mx-1" target="_blank" href="@server.DemoIndex">
+                                                    <i class="bi bi-camera-video icon-in-a-button-small align-middle"></i> <span class="align-middle">Demos</span>
+                                                </a>
+                                            }
                                         </span>
                                         <span class="mb-4">
                                             <small><strong>Server IP</strong>: @server.IpAndPort</small>
-                                            @if (server.JoinLink != null)
-                                            {
-                                                <a role="button" title="Join server (requires joinme.click/download)" href="@server.JoinLink" class="btn btn-dark btn-sm mx-2">
-                                                    <i class="bi bi-joystick-btn icon-in-a-button-small"></i> Join
-                                                </a>
-                                            }
                                         </span>
                                     </div>
                                     @if (server.NumPlayersWithoutBots > 0)

--- a/src/BF2TV.Frontend/Pages/FAQ.razor
+++ b/src/BF2TV.Frontend/Pages/FAQ.razor
@@ -25,9 +25,14 @@
             </a>
         </p>
 
-        <h5 id="missing-join-button" class="mt-5">Why do some servers not have a join button?</h5>
+        <h5 id="missing-join-button" class="mt-5">Why do some servers not have a "Join server" button?</h5>
         <p>
             The joinme.click launcher does not support joining servers with a password. It also only supports some of the more popular mods for Battlefield 2. Which is why the join button is not present for password protected servers as well as servers with less popular mods.
+        </p>
+        
+        <h5 id="missing-discord-button" class="mt-5">Why do some servers not have a "Join Discord" button?</h5>
+        <p>
+            The "Join Discord" button is only available if the server admins added a Discord invite to their "Sponsor Text". 
         </p>
 
         <h5 id="custom-maps" class="mt-5">Where can I download custom modded maps for competitive BF2 modes like "2 vs. 2 in a Helicopter"?</h5>


### PR DESCRIPTION
Just as the title suggests, this add the "Join Discord" and "Demo" buttons to the dashboard. This should make them a lot more usable, as users don't have to open the server details first.