### PR TITLE
Update FAQ.razor to change BF2Hub to B2BF2

### DIFF
--- a/src/BF2TV.Frontend/Pages/FAQ.razor
+++ b/src/BF2TV.Frontend/Pages/FAQ.razor
@@ -43,13 +43,13 @@
         <h5 id="how-to-play" class="mt-5">How can I play Battlefield 2 in @DateTime.Now.Year?</h5>
         <ol>
             <li>
-                Download and install the <a class="link" target="_blank" href="https://www.bf2hub.com">BF2Hub Client</a>
+                Register for an account at <a class="link" target="_blank" href="https://b2bf2.net">Back 2 Battlefield 2</a>
             </li>
             <li>
-                Download and install the <a class="link" target="_blank" href="https://mega.nz/file/0wJhRYhK#9zYuv09dWSE0eQ9mFHgx71hLWW2AOKq3X3n7bKRJvUY">Full BF2 Setup with license verification + patches + addons included, provided by Lost-Soldiers.org</a>
+                Download and install the <a class="link" target="_blank" href="https://b2bf2.net/download">Back 2 Battlefield Launcher</a>
             </li>
             <li>
-                Open BF2Hub: Make sure all top buttons are green. If something is red, click on the red area and patch the selected BF2 files. Then everything should work.
+                Open the Back 2 Battlefield Launcher: Make sure you are logged in and the game finished downloading. Press start to launch the game and make sure to keep the launcher open during play
             </li>
             <li>
                 Download and install the <a class="link" target="_blank" href="https://github.com/TwitchPlaysBF2/BF2Dashboard/releases/latest/download/BF2.TV_App_Setup.exe">BF2.TV Desktop App for Windows</a> to use the [Join Server] button directly from <b>BF2.TV</b> (browser & app version)


### PR DESCRIPTION
Title says it all, with the ongoing maintenance at BF2Hub users are confused when they try to register. Redirect them to B2BF2 to download and play BF2