### PR TITLE
feat: Use playerpath.link for player stats profile links

### DIFF
--- a/src/BF2TV.Domain/BattlefieldApi/Player.cs
+++ b/src/BF2TV.Domain/BattlefieldApi/Player.cs
@@ -14,9 +14,7 @@ public class Player
 
     public string FullName => Tag + " " + Name;
 
-    // Long names of player may be cut off if used in combination with a clan tag/prefix,
-    // meaning linking to the cut-off name would lead to a 404 => link to profile based on pid instead
-    public string ProfileUrl => $"https://www.bf2hub.com/stats/{Pid}";
+    public string ProfileUrl => $"https://playerpath.link/p/{Pid}";
     
     [JsonPropertyName("pid")]
     public int? Pid { get; set; }

--- a/src/BF2TV.Domain/Models/FriendModel.cs
+++ b/src/BF2TV.Domain/Models/FriendModel.cs
@@ -8,7 +8,7 @@ public class FriendModel
 
     public string DisplayName { get; private init; }
 
-    public string ProfileUrl => FindProfileUrl();
+    public string? ProfileUrl => Player?.ProfileUrl;
 
     public override string ToString() => DisplayName;
 
@@ -40,19 +40,5 @@ public class FriendModel
 
     private FriendModel()
     {
-    }
-
-    private string FindProfileUrl()
-    {
-        return Player?.ProfileUrl ?? $"https://www.bf2hub.com/player/{PlayerNameWithoutPrefix()}";
-
-        // TODO: Resolve persisted friend name (without prefix), once friendlist-persistence is is more than just 1x string
-        string PlayerNameWithoutPrefix()
-        {
-            // We need the playername without prefix. As of now, Player instance isn't loaded for offline friends.
-            // (Quick & dirty, until the terrible friendlist persistence is done better)
-            // (iirc, I ran into performance issues persisiting more than 1x string in local browser storage)
-            return DisplayName.Trim().Split(' ').LastOrDefault() ?? DisplayName;
-        }
     }
 }

--- a/src/BF2TV.Frontend/Pages/Dashboard.razor
+++ b/src/BF2TV.Frontend/Pages/Dashboard.razor
@@ -56,9 +56,16 @@
                         {
                             <li class="m-2">
                                 <i class="bi bi-circle-fill" style="color: green; font-size: 11pt;"></i>
-                                <a href="@friend.ProfileUrl" target="_blank" style="text-decoration: none; opacity: .75" title="Open BF2Hub profile">
-                                    @friend.DisplayName
-                                </a>
+                                @if (friend.ProfileUrl != null)
+                                {
+                                    <a href="@friend.ProfileUrl" target="_blank" style="text-decoration: none; opacity: .75" title="Open stats profile">
+                                        @friend.DisplayName
+                                    </a>
+                                }
+                                else
+                                {
+                                    <span style="text-decoration: none; opacity: .75">@friend.DisplayName</span>
+                                }
                                 <span style="font-size: 10pt; color: #767676">
                                     @friend.ServerInfo.MapNameAndSize @@ <LinkedServer Server="friend.ServerInfo"/>
                                     <a role="button"
@@ -205,7 +212,7 @@ else
                                                 {
                                                     <tr>
                                                         <td style="vertical-align: center;">
-                                                            <a title="Open BF2Hub profile" class="link-light text-nowrap text-decoration-none" target="_blank"
+                                                            <a title="Open stats profile" class="link-light text-nowrap text-decoration-none" target="_blank"
                                                                href="@player.ProfileUrl">
                                                                 <span style="color: @(player.IsFriend ? "darkseagreen" : "")">@player.FullName</span>
                                                             </a>
@@ -240,7 +247,7 @@ else
                                                 {
                                                     <tr>
                                                         <td>
-                                                            <a title="Open BF2Hub profile" class="link-light text-nowrap text-decoration-none" target="_blank"
+                                                            <a title="Open stats profile" class="link-light text-nowrap text-decoration-none" target="_blank"
                                                                href="@player.ProfileUrl">
                                                                 <span style="color: @(player.IsFriend ? "darkseagreen" : "")">@player.FullName</span>
                                                             </a>
@@ -382,7 +389,7 @@ else
                                                     {
                                                         <tr>
                                                             <td>
-                                                                <a title="Open BF2Hub profile" class="link-light text-nowrap text-decoration-none" target="_blank"
+                                                                <a title="Open stats profile" class="link-light text-nowrap text-decoration-none" target="_blank"
                                                                    href="@player.ProfileUrl">
                                                                     <span style="color: @(player.IsFriend ? "darkseagreen" : "")">@player.FullName</span>
                                                                 </a>
@@ -417,7 +424,7 @@ else
                                                     {
                                                         <tr>
                                                             <td>
-                                                                <a title="Open BF2Hub profile" class="link-light text-nowrap text-decoration-none" target="_blank"
+                                                                <a title="Open stats profile" class="link-light text-nowrap text-decoration-none" target="_blank"
                                                                    href="@player.ProfileUrl">
                                                                     <span style="color: @(player.IsFriend ? "darkseagreen" : "")">@player.FullName</span>
                                                                 </a>

--- a/src/BF2TV.Frontend/Pages/FriendList.razor
+++ b/src/BF2TV.Frontend/Pages/FriendList.razor
@@ -23,9 +23,17 @@
                 {
                     <li class="m-2">
                         <i class="bi bi-circle-fill" style="color: green; font-size: 11pt;"></i>
-                        <a href="@friend.ProfileUrl" target="_blank" style="text-decoration: none; opacity: .75" title="Open BF2Hub profile">
-                            @friend.DisplayName
-                        </a>
+                        @if (friend.ProfileUrl != null)
+                        {
+                            <a href="@friend.ProfileUrl" target="_blank" style="text-decoration: none; opacity: .75" title="Open stats profile">
+                                @friend.DisplayName
+                            </a>
+                        }
+                        else
+                        {
+                            <span style="text-decoration: none; opacity: .75">@friend.DisplayName</span>
+                        }
+                        
                         <span style="font-size: 10pt; color: #767676">
                             @friend.ServerInfo.MapNameAndSize @@ <a href="servers/@friend.ServerInfo.IpAndPort" style="color: slategrey">@friend.ServerInfo.ServerName</a>
                             (@friend.ServerInfo.CurrentPlayerCountWithoutBots/@friend.ServerInfo.MaxPlayerCount)
@@ -64,9 +72,16 @@
                 {
                     <li style="opacity: .5" class="mb-2">
                         <i class="bi bi-circle-fill" style="color: #767676; font-size: 11pt;"></i>
-                        <a href="@friend.ProfileUrl" target="_blank" style="text-decoration: none; opacity: .75" title="Open BF2Hub profile">
-                            @friend.DisplayName
-                        </a>
+                        @if (friend.ProfileUrl != null)
+                        {
+                            <a href="@friend.ProfileUrl" target="_blank" style="text-decoration: none; opacity: .75" title="Open stats profile">
+                                @friend.DisplayName
+                            </a>
+                        }
+                        else
+                        {
+                            <span style="text-decoration: none; opacity: .75">@friend.DisplayName</span>
+                        }
                         <i class="btn btn-sm btn-outline-warning bi bi-person-dash grow ms-2 me-2" @onclick="() => RemoveFriend(friend)" title="Remove friend"></i>
                         <FriendAlertComponent Friend="@friend" />
                     </li>

--- a/src/BF2TV.Frontend/Pages/ServerPage.razor
+++ b/src/BF2TV.Frontend/Pages/ServerPage.razor
@@ -81,7 +81,7 @@
                             {
                                 <tr>
                                     <td>
-                                        <a title="Open BF2Hub profile" class="link-light text-nowrap text-decoration-none" target="_blank"
+                                        <a title="Open stats profile" class="link-light text-nowrap text-decoration-none" target="_blank"
                                            href="@player.ProfileUrl">
                                             <span style="color: @(player.IsFriend ? "darkseagreen" : "")">@player.FullName</span>
                                         </a>
@@ -112,7 +112,7 @@
                             {
                                 <tr>
                                     <td>
-                                        <a title="Open BF2Hub profile" class="link-light text-nowrap text-decoration-none" target="_blank"
+                                        <a title="Open stats profile" class="link-light text-nowrap text-decoration-none" target="_blank"
                                            href="@player.ProfileUrl">
                                             <span style="color: @(player.IsFriend ? "darkseagreen" : "")">@player.FullName</span>
                                         </a>


### PR DESCRIPTION
Dynamically route to player's profile instead of always linking to BF2Hub.com, even for non-BF2Hub players.

playerpath.link is a simple frontend for [playerpath](https://github.com/cetteup/playerpath)'s API, which uses data from [bf2opendata](https://github.com/art567/bf2opendata). The site simply looks up which provider a player is using and (if possible) redirects the user to the relevant provider's website. Currently supports B2BF2, PlayBF2 and BF2Hub. OpenSpy doesn't have any form of stats and thus no site to redirect to.

Examples:
* https://playerpath.link/p/483919 [B2BF2]
* https://playerpath.link/p/482826976 [PlayBF2]
* https://playerpath.link/p/500362798 [BF2Hub]
* https://playerpath.link/p/10072436 [OpenSpy]
* https://playerpath.link/p/1 [not found]
* https://playerpath.link/p/43373217 [conflict/player PID not unique]
* https://playerpath.link/p/abcdef [invalid PID]