### PR TITLE
fix: don't add player stats profile link for local profiles

### DIFF
--- a/src/BF2TV.Domain/BattlefieldApi/Player.cs
+++ b/src/BF2TV.Domain/BattlefieldApi/Player.cs
@@ -14,7 +14,9 @@ public class Player
 
     public string FullName => Tag + " " + Name;
 
-    public string ProfileUrl => $"https://playerpath.link/p/{Pid}";
+    // When players join online server with local profiles, they receive a pid of 0.
+    // It makes no sense to link to them, so only provide a ProfileUrl for players with a non-zero pid.
+    public string? ProfileUrl => Pid > 0 ? $"https://playerpath.link/p/{Pid}" : null;
     
     [JsonPropertyName("pid")]
     public int? Pid { get; set; }

--- a/src/BF2TV.Frontend/Pages/Dashboard.razor
+++ b/src/BF2TV.Frontend/Pages/Dashboard.razor
@@ -212,10 +212,17 @@ else
                                                 {
                                                     <tr>
                                                         <td style="vertical-align: center;">
-                                                            <a title="Open stats profile" class="link-light text-nowrap text-decoration-none" target="_blank"
-                                                               href="@player.ProfileUrl">
+                                                            @if (@player.ProfileUrl != null)
+                                                            {
+                                                                <a title="Open stats profile" class="link-light text-nowrap text-decoration-none" target="_blank"
+                                                                   href="@player.ProfileUrl">
+                                                                    <span style="color: @(player.IsFriend ? "darkseagreen" : "")">@player.FullName</span>
+                                                                </a>
+                                                            }
+                                                            else
+                                                            {
                                                                 <span style="color: @(player.IsFriend ? "darkseagreen" : "")">@player.FullName</span>
-                                                            </a>
+                                                            }
                                                         </td>
                                                         <td class="text-center">
                                                             @player.Score
@@ -247,10 +254,17 @@ else
                                                 {
                                                     <tr>
                                                         <td>
-                                                            <a title="Open stats profile" class="link-light text-nowrap text-decoration-none" target="_blank"
-                                                               href="@player.ProfileUrl">
+                                                            @if (@player.ProfileUrl != null)
+                                                            {
+                                                                <a title="Open stats profile" class="link-light text-nowrap text-decoration-none" target="_blank"
+                                                                   href="@player.ProfileUrl">
+                                                                    <span style="color: @(player.IsFriend ? "darkseagreen" : "")">@player.FullName</span>
+                                                                </a>
+                                                            }
+                                                            else
+                                                            {
                                                                 <span style="color: @(player.IsFriend ? "darkseagreen" : "")">@player.FullName</span>
-                                                            </a>
+                                                            }
                                                         </td>
                                                         <td class="text-center">
                                                             @player.Score
@@ -389,10 +403,17 @@ else
                                                     {
                                                         <tr>
                                                             <td>
-                                                                <a title="Open stats profile" class="link-light text-nowrap text-decoration-none" target="_blank"
-                                                                   href="@player.ProfileUrl">
+                                                                @if (@player.ProfileUrl != null)
+                                                                {
+                                                                    <a title="Open stats profile" class="link-light text-nowrap text-decoration-none" target="_blank"
+                                                                       href="@player.ProfileUrl">
+                                                                        <span style="color: @(player.IsFriend ? "darkseagreen" : "")">@player.FullName</span>
+                                                                    </a>
+                                                                }
+                                                                else
+                                                                {
                                                                     <span style="color: @(player.IsFriend ? "darkseagreen" : "")">@player.FullName</span>
-                                                                </a>
+                                                                }
                                                             </td>
                                                             <td class="text-center">
                                                                 @player.Score
@@ -424,10 +445,17 @@ else
                                                     {
                                                         <tr>
                                                             <td>
-                                                                <a title="Open stats profile" class="link-light text-nowrap text-decoration-none" target="_blank"
-                                                                   href="@player.ProfileUrl">
+                                                                @if (@player.ProfileUrl != null)
+                                                                {
+                                                                    <a title="Open stats profile" class="link-light text-nowrap text-decoration-none" target="_blank"
+                                                                       href="@player.ProfileUrl">
+                                                                        <span style="color: @(player.IsFriend ? "darkseagreen" : "")">@player.FullName</span>
+                                                                    </a>
+                                                                }
+                                                                else
+                                                                {
                                                                     <span style="color: @(player.IsFriend ? "darkseagreen" : "")">@player.FullName</span>
-                                                                </a>
+                                                                }
                                                             </td>
                                                             <td class="text-center">
                                                                 @player.Score

--- a/src/BF2TV.Frontend/Pages/ServerPage.razor
+++ b/src/BF2TV.Frontend/Pages/ServerPage.razor
@@ -81,10 +81,17 @@
                             {
                                 <tr>
                                     <td>
-                                        <a title="Open stats profile" class="link-light text-nowrap text-decoration-none" target="_blank"
-                                           href="@player.ProfileUrl">
+                                        @if (@player.ProfileUrl != null)
+                                        {
+                                            <a title="Open stats profile" class="link-light text-nowrap text-decoration-none" target="_blank"
+                                               href="@player.ProfileUrl">
+                                                <span style="color: @(player.IsFriend ? "darkseagreen" : "")">@player.FullName</span>
+                                            </a>
+                                        }
+                                        else
+                                        {
                                             <span style="color: @(player.IsFriend ? "darkseagreen" : "")">@player.FullName</span>
-                                        </a>
+                                        }
                                     </td>
                                     <td class="text-center">
                                         @player.Score
@@ -112,10 +119,17 @@
                             {
                                 <tr>
                                     <td>
-                                        <a title="Open stats profile" class="link-light text-nowrap text-decoration-none" target="_blank"
-                                           href="@player.ProfileUrl">
+                                        @if (@player.ProfileUrl != null)
+                                        {
+                                            <a title="Open stats profile" class="link-light text-nowrap text-decoration-none" target="_blank"
+                                               href="@player.ProfileUrl">
+                                                <span style="color: @(player.IsFriend ? "darkseagreen" : "")">@player.FullName</span>
+                                            </a>
+                                        }
+                                        else
+                                        {
                                             <span style="color: @(player.IsFriend ? "darkseagreen" : "")">@player.FullName</span>
-                                        </a>
+                                        }
                                     </td>
                                     <td class="text-center">
                                         @player.Score


### PR DESCRIPTION
Noticed that local/singleplayer profiles were linking to https://playerpath.link/p/0, which shows a 400 Bad Request. To avoid that, only add the link if `pid > 0`.

P.S.: Yes, you can join internet server using local profiles - but only unranked ones. And you need to use the command line flags, as you have no way of selecting those servers in game.