### PR TITLE
Revert "Update FAQ.razor"

### DIFF
--- a/src/BF2TV.Frontend/Pages/FAQ.razor
+++ b/src/BF2TV.Frontend/Pages/FAQ.razor
@@ -53,13 +53,13 @@
         <h5 id="how-to-play" class="mt-5">How can I play Battlefield 2 in @DateTime.Now.Year?</h5>
         <ol>
             <li>
-                Register for an account at <a class="link" target="_blank" href="https://b2bf2.net">Back 2 Battlefield 2</a>
+                Download and install the <a class="link" target="_blank" href="https://www.bf2hub.com">BF2Hub Client</a>
             </li>
             <li>
-                Download and install the <a class="link" target="_blank" href="https://b2bf2.net/download">Back 2 Battlefield Launcher</a>
+                Download and install the <a class="link" target="_blank" href="https://mega.nz/file/0wJhRYhK#9zYuv09dWSE0eQ9mFHgx71hLWW2AOKq3X3n7bKRJvUY">Full BF2 Setup with license verification + patches + addons included, provided by Lost-Soldiers.org</a>
             </li>
             <li>
-                Open the Back 2 Battlefield Launcher: Make sure you are logged in and the game finished downloading. Press start to launch the game and make sure to keep the launcher open during play
+                Open BF2Hub: Make sure all top buttons are green. If something is red, click on the red area and patch the selected BF2 files. Then everything should work.
             </li>
             <li>
                 Download and install the <a class="link" target="_blank" href="https://github.com/TwitchPlaysBF2/BF2Dashboard/releases/latest/download/BF2.TV_App_Setup.exe">BF2.TV Desktop App for Windows</a> to use the [Join Server] button directly from <b>BF2.TV</b> (browser & app version)


### PR DESCRIPTION
B2BF2 has not had any ranked servers since BF2Hub returned from maintenance. Players seem to be more confused than anything about not being able to rank up while using B2BF2. For the time being, I think it's time to return to referencing BF2Hub in the FAQ.