### PR TITLE
feat: pause periodic refresh while in the background

### DIFF
--- a/src/BF2TV.BlazorWasm/wwwroot/index.html
+++ b/src/BF2TV.BlazorWasm/wwwroot/index.html
@@ -35,6 +35,7 @@
     <a class="reload" href="">Reload</a>
     <a class="dismiss">🗙</a>
 </div>
+<script src="_content/BF2TV.Frontend/js/focusInterop.js"></script>
 <script src="_framework/blazor.webassembly.js"></script>
 <script src="_content/BF2TV.Frontend/css/bootstrap/bootstrap.bundle.min.js"></script>
 </body>

--- a/src/BF2TV.Frontend/Pages/Dashboard.razor
+++ b/src/BF2TV.Frontend/Pages/Dashboard.razor
@@ -13,6 +13,7 @@
 @inject IEnvironment Environment
 @inject IActivePlayerLookupService ActivePlayerLookupService
 @inject IPeriodicRefresher PeriodicRefresher
+@inject IJSRuntime JsRuntime
 
 @if (Environment.IsApp() && _activePlayerName != null)
 {
@@ -574,4 +575,40 @@ else
         "btn btn-sm btn-outline-warning bi bi-person-dash grow" :
         "btn btn-sm btn-outline-success bi bi-person-plus grow";
 
+}
+
+@code {
+    private bool _paused;
+    private DotNetObjectReference<Dashboard>? _dotNetRef;
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (firstRender)
+        {
+            _dotNetRef = DotNetObjectReference.Create(this);
+            await JsRuntime.InvokeVoidAsync("focusInterop.registerFocusHandlers", _dotNetRef);
+        }
+    }
+
+    [JSInvokable]
+    public void OnWindowBlur()
+    {
+        // No need to pause updates if periodic refresh is disabled
+        // Must not pause refresh if alerts are enabled and configured
+        if (!PeriodicRefresher.IsEnabled || (AlertState.Value.AreAllAlertsEnabled != false && AlertState.Value.FriendIsOnServerConditions.Any(c => c.IsEnabled))) return;
+        
+        PeriodicRefresher.UpdateSetting(false);
+        _paused = true;
+    }
+
+    [JSInvokable]
+    public void OnWindowFocus() {
+        if (!_paused) return;
+
+        PeriodicRefresher.UpdateSetting(true);
+        _paused = false;
+        
+        // Force an immediate update after regaining focus
+        Dispatcher.Dispatch(new InitializeServerListsAction());
+    }
 }

--- a/src/BF2TV.Frontend/wwwroot/js/focusInterop.js
+++ b/src/BF2TV.Frontend/wwwroot/js/focusInterop.js
@@ -1,0 +1,12 @@
+﻿// wwwroot/focusInterop.js
+window.focusInterop = {
+    registerFocusHandlers: function (dotNetHelper) {
+        window.addEventListener("blur", () => {
+            dotNetHelper.invokeMethodAsync("OnWindowBlur");
+        });
+
+        window.addEventListener("focus", () => {
+            dotNetHelper.invokeMethodAsync("OnWindowFocus");
+        });
+    }
+};

--- a/src/BF2TV.WindowsApp/wwwroot/index.html
+++ b/src/BF2TV.WindowsApp/wwwroot/index.html
@@ -24,6 +24,7 @@
     <a class="dismiss">🗙</a>
 </div>
 
+<script src="_content/BF2TV.Frontend/js/focusInterop.js"></script>
 <script src="_framework/blazor.webview.js"></script>
 <script src="_content/BF2TV.Frontend/css/bootstrap/bootstrap.bundle.min.js"></script>
 </body>


### PR DESCRIPTION
Inspired by how @tanstack/react-query allows [pausing refetch](https://tanstack.com/query/latest/docs/framework/react/guides/window-focus-refetching) while the website is open in the background.

If refresh is enabled, pause on focus loss and resume when focus is regained. This approach should save a lot of bflist API requests caused by users just keeping bf2.tv open in the background.

**Note:** In contrast to #65, the periodic refresh is *not* paused if the user has any active alerts configured.